### PR TITLE
Increased busy timeout. Fixes issue with 7.5" displays

### DIFF
--- a/GxEPD2_32_3C_X.cpp
+++ b/GxEPD2_32_3C_X.cpp
@@ -581,7 +581,7 @@ void GxEPD2_32_3C_X::_waitWhileBusy(const char* comment)
   {
     if (digitalRead(_busy) != _busy_active_level) break;
     delay(1);
-    if (micros() - start > 20000000) // >14.9s !
+    if (micros() - start > 40000000) // >32.6s !
     {
       Serial.println("Busy Timeout!");
       break;


### PR DESCRIPTION
WaveShare 7.5-inch 3-color display takes about 32.6 seconds for updates.